### PR TITLE
Fix according GP-4269

### DIFF
--- a/src/main/java/ghidrust/decompiler/RustDecPlugin.java
+++ b/src/main/java/ghidrust/decompiler/RustDecPlugin.java
@@ -35,7 +35,7 @@ import docking.action.MenuData;
 @PluginInfo(
 	status = PluginStatus.STABLE,
 	packageName = "HELLO",
-	category = PluginCategoryNames.DECOMPILER,
+	category = PluginCategoryNames.ANALYSIS,
 	shortDescription = "Rust Decompiler",
 	description = "Decompile Rust binaries' assembly to Rust code",
     eventsConsumed = {


### PR DESCRIPTION
In the commit [GP-4269](https://github.com/NationalSecurityAgency/ghidra/commit/ca9cfe9f9a924a7407702fcf94cc9f6f397f33a4), the Ghidra developers changed the naming of plugin categories, which made GhidRust uncompilable. The problem is solved by changing PluginCategoryName to match the new naming.